### PR TITLE
Add enableBackNavigation to pushToSwiftUiView()

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,19 @@ NavigationView {
     Button(action: {
       CUNavigation.pushToSwiftUiView(YOUR_VIEW_HERE)
     }){
-      Text("Push To SwiftUI View")
+      Text("Push To SwiftUI view")
+    }
+    
+    Button(action: {
+      CUNavigation.pushToSwiftUiView(YOUR_VIEW_HERE, enableBackNavigation: false)
+    }){
+      Text("Push To SwiftUI view and disbale swipe right to go back gesture")
+    }
+    
+    Button(action: {
+      CUNavigation.pop()
+    }){
+      Text("Pop to previous view")
     }
     
     Button(action: {
@@ -104,4 +116,3 @@ CUAlertMessage.show("HELOOOOO", subTitle: "WORLD", type: .success)
 CUAlertMessage.show("HELOOOOO", type: .info)
 CUAlertMessage.show("HELOOOOO", subTitle: "WORLD", type: .info)
 ```
-

--- a/Sources/CleanUI/Main/Classes/CUNavigation.swift
+++ b/Sources/CleanUI/Main/Classes/CUNavigation.swift
@@ -85,11 +85,14 @@ public class CUNavigation {
     }
     
     /// Try's to push to a SwiftUI View inside the current UINavigationController
-    public static func pushToSwiftUiView<Content: View>(_ view: Content, animated: Bool = true){
+    /// - Parameter animated: Animated, default `true`
+    /// - Parameter enableBackNavigation: Enable or disbale back swipe gesture, default `true`
+    public static func pushToSwiftUiView<Content: View>(_ view: Content, animated: Bool = true, enableBackNavigation: Bool = true){
         if let navigationController = self.getCurrentNavigationController() {
             let viewController = UIHostingController(rootView: view)
             viewController.navigationItem.largeTitleDisplayMode = .never
             navigationController.pushViewController(viewController, animated: animated)
+            navigationController.interactivePopGestureRecognizer?.isEnabled = enableBackNavigation
         }
     }
     


### PR DESCRIPTION
The enableBackNavigation parameter in pushToSwiftUiView() controls if the user can swipe from left to right to go back one navigation hierarchy. By settings it to false, the gesture is disabled so that you can only navigate back by using pop().